### PR TITLE
Set urllib3 to 1.26.15

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ alembic
 pytest
 black
 twilio
+urllib3==1.26.15


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
401s were being thrown (for me) on all endpoints because of this [issue](https://github.com/ionrock/cachecontrol/issues/292). The fix was to set urllib3 to 1.26.15. 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify endpoints still work


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [ ] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [ ] I have updated other Docs as needed
