### PR TITLE
rename sign in logs functions

### DIFF
--- a/backend/app/rest/auth_routes.py
+++ b/backend/app/rest/auth_routes.py
@@ -133,7 +133,7 @@ def two_fa():
             value=auth_dto.refresh_token,
             **cookie_options,
         )
-        sign_in_logs_service.create_log(auth_dto.id)
+        sign_in_logs_service.create_sign_in_log(auth_dto.id)
         return response, 200
 
     except Exception as e:

--- a/backend/app/rest/sign_in_logs_routes.py
+++ b/backend/app/rest/sign_in_logs_routes.py
@@ -60,7 +60,7 @@ def filter_logs():
 
     if email and start_date and end_date:
         try:
-            logs = sign_in_logs_service.get_logs_by_date_range_and_id(
+            logs = sign_in_logs_service.get_sign_in_logs_by_date_range_and_id(
                 start_date, end_date, user_id
             )
             return logs, 200
@@ -72,7 +72,7 @@ def filter_logs():
             )
     elif email and not (start_date and end_date):
         try:
-            logs = sign_in_logs_service.get_logs_by_id(user_id)
+            logs = sign_in_logs_service.get_sign_in_logs_by_id(user_id)
             return logs, 200
         except Exception as e:
             error_message = getattr(e, "message", None)
@@ -83,7 +83,7 @@ def filter_logs():
     elif start_date and end_date:
         try:
             # return as json object
-            logs = sign_in_logs_service.get_logs_by_date_range(start_date, end_date)
+            logs = sign_in_logs_service.get_sign_in_logs_by_date_range(start_date, end_date)
             return logs, 200
 
         except Exception as e:

--- a/backend/app/services/implementations/sign_in_logs_service.py
+++ b/backend/app/services/implementations/sign_in_logs_service.py
@@ -21,7 +21,7 @@ class SignInLogService(ISignInLogService):
         """
         self.logger = logger
 
-    def create_log(self, user_id):
+    def create_sign_in_log(self, user_id):
         sign_in = {"id": user_id, "time": datetime.now()}
         try:
             new_sign_in = SignInLogs(**sign_in)
@@ -30,7 +30,7 @@ class SignInLogService(ISignInLogService):
         except Exception as postgres_error:
             raise postgres_error
 
-    def get_logs_list(self, logs):
+    def get_sign_in_logs_list(self, logs):
         try:
             logs_list = []
             # return as json object
@@ -46,25 +46,25 @@ class SignInLogService(ISignInLogService):
         except Exception as postgres_error:
             raise postgres_error
 
-    def get_logs_by_id(self, user_id):
+    def get_sign_in_logs_by_id(self, user_id):
         try:
             sign_in_logs = SignInLogs.query.filter_by(id=user_id).order_by(
                 SignInLogs.time.desc()
             )[:100]
-            return self.get_logs_list(sign_in_logs)
+            return self.get_sign_in_logs_list(sign_in_logs)
         except Exception as postgres_error:
             raise postgres_error
 
-    def get_logs_by_date_range(self, start_date, end_date):
+    def get_sign_in_logs_by_date_range(self, start_date, end_date):
         try:
             sign_in_logs = SignInLogs.query.filter(
                 SignInLogs.time >= start_date, SignInLogs.time <= end_date
             ).order_by(SignInLogs.time.desc())[:100]
-            return self.get_logs_list(sign_in_logs)
+            return self.get_sign_in_logs_list(sign_in_logs)
         except Exception as postgres_error:
             raise postgres_error
 
-    def get_logs_by_date_range_and_id(self, start_date, end_date, user_id):
+    def get_sign_in_logs_by_date_range_and_id(self, start_date, end_date, user_id):
         try:
             sign_in_logs = (
                 SignInLogs.query.filter(
@@ -73,6 +73,6 @@ class SignInLogService(ISignInLogService):
                 .filter_by(id=user_id)
                 .order_by(SignInLogs.time.desc())[:100]
             )
-            return self.get_logs_list(sign_in_logs)
+            return self.get_sign_in_logs_list(sign_in_logs)
         except Exception as postgres_error:
             raise postgres_error

--- a/backend/app/services/interfaces/sign_in_logs_service.py
+++ b/backend/app/services/interfaces/sign_in_logs_service.py
@@ -7,7 +7,7 @@ class ISignInLogService(ABC):
     """
 
     @abstractmethod
-    def create_log(self, user_id):
+    def create_sign_in_log(self, user_id):
         """
         Create a user, email verification configurable
 


### PR DESCRIPTION
Prematurely merged in https://github.com/uwblueprint/supportive-housing/pull/106. This is to address Safwaan's last comment about renaming all the functions in `sign_in_logs_service.py` from `*-logs` to `*-sign_in_logs`


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [ ] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [ ] I have updated other Docs as needed
