### PR TITLE
Sticky Table Headers

### DIFF
--- a/frontend/src/components/pages/AdminControls/EmployeeDirectoryTable.tsx
+++ b/frontend/src/components/pages/AdminControls/EmployeeDirectoryTable.tsx
@@ -174,7 +174,7 @@ const EmployeeDirectoryTable = ({
         ref={tableRef}
       >
         <Table variant="showTable" verticalAlign="middle">
-          <Thead position="sticky" top={0} zIndex="docked">
+          <Thead>
             <Tr>
               <Th>Employee Name</Th>
               <Th>Email</Th>

--- a/frontend/src/components/pages/AdminControls/EmployeeDirectoryTable.tsx
+++ b/frontend/src/components/pages/AdminControls/EmployeeDirectoryTable.tsx
@@ -170,11 +170,11 @@ const EmployeeDirectoryTable = ({
       <TableContainer
         marginTop="12px"
         height="70vh"
-        overflowY="scroll"
+        overflowY="unset"
         ref={tableRef}
       >
         <Table variant="showTable" verticalAlign="middle">
-          <Thead>
+          <Thead position="sticky" top={0} zIndex="docked">
             <Tr>
               <Th>Employee Name</Th>
               <Th>Email</Th>

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -142,7 +142,7 @@ const LogRecordsTable = ({
           ref={tableRef}
         >
           <Table variant="showTable" verticalAlign="middle">
-            <Thead position="sticky" top={0} zIndex="docked">
+            <Thead>
               <Tr>
                 <Th>Date</Th>
                 <Th>Time</Th>

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -138,11 +138,11 @@ const LogRecordsTable = ({
         <TableContainer
           marginTop="12px"
           height="70vh"
-          overflowY="scroll"
+          overflowY="unset"
           ref={tableRef}
         >
           <Table variant="showTable" verticalAlign="middle">
-            <Thead>
+            <Thead position="sticky" top={0} zIndex="docked">
               <Tr>
                 <Th>Date</Th>
                 <Th>Time</Th>
@@ -172,35 +172,35 @@ const LogRecordsTable = ({
                       <Td width="5%">{`${record.employee.firstName} ${record.employee.lastName}`}</Td>
                       <Td width="5%">
                         {record.attnTo && record.attnTo.firstName !== null &&
-                        record.attnTo.lastName !== null
+                          record.attnTo.lastName !== null
                           ? `${record.attnTo.firstName} ${record.attnTo.lastName}`
                           : ""}
                       </Td>
                       <Td width="5%">
                         {(authenticatedUser?.role === "Admin" ||
                           authenticatedUser?.id === record.employee.id) && (
-                          <Menu>
-                            <MenuButton
-                              as={IconButton}
-                              aria-label="Options"
-                              icon={<VscKebabVertical />}
-                              w="36px"
-                              variant="ghost"
-                            />
-                            <MenuList>
-                              <MenuItem
-                                onClick={() => handleEditToggle(record.logId)}
-                              >
-                                Edit Log Record
+                            <Menu>
+                              <MenuButton
+                                as={IconButton}
+                                aria-label="Options"
+                                icon={<VscKebabVertical />}
+                                w="36px"
+                                variant="ghost"
+                              />
+                              <MenuList>
+                                <MenuItem
+                                  onClick={() => handleEditToggle(record.logId)}
+                                >
+                                  Edit Log Record
                               </MenuItem>
-                              <MenuItem
-                                onClick={() => handleDeleteToggle(record.logId)}
-                              >
-                                Delete Log Record
+                                <MenuItem
+                                  onClick={() => handleDeleteToggle(record.logId)}
+                                >
+                                  Delete Log Record
                               </MenuItem>
-                            </MenuList>
-                          </Menu>
-                        )}
+                              </MenuList>
+                            </Menu>
+                          )}
                       </Td>
                     </Tr>
 

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -171,36 +171,37 @@ const LogRecordsTable = ({
                       </Td>
                       <Td width="5%">{`${record.employee.firstName} ${record.employee.lastName}`}</Td>
                       <Td width="5%">
-                        {record.attnTo && record.attnTo.firstName !== null &&
-                          record.attnTo.lastName !== null
+                        {record.attnTo &&
+                        record.attnTo.firstName !== null &&
+                        record.attnTo.lastName !== null
                           ? `${record.attnTo.firstName} ${record.attnTo.lastName}`
                           : ""}
                       </Td>
                       <Td width="5%">
                         {(authenticatedUser?.role === "Admin" ||
                           authenticatedUser?.id === record.employee.id) && (
-                            <Menu>
-                              <MenuButton
-                                as={IconButton}
-                                aria-label="Options"
-                                icon={<VscKebabVertical />}
-                                w="36px"
-                                variant="ghost"
-                              />
-                              <MenuList>
-                                <MenuItem
-                                  onClick={() => handleEditToggle(record.logId)}
-                                >
-                                  Edit Log Record
+                          <Menu>
+                            <MenuButton
+                              as={IconButton}
+                              aria-label="Options"
+                              icon={<VscKebabVertical />}
+                              w="36px"
+                              variant="ghost"
+                            />
+                            <MenuList>
+                              <MenuItem
+                                onClick={() => handleEditToggle(record.logId)}
+                              >
+                                Edit Log Record
                               </MenuItem>
-                                <MenuItem
-                                  onClick={() => handleDeleteToggle(record.logId)}
-                                >
-                                  Delete Log Record
+                              <MenuItem
+                                onClick={() => handleDeleteToggle(record.logId)}
+                              >
+                                Delete Log Record
                               </MenuItem>
-                              </MenuList>
-                            </Menu>
-                          )}
+                            </MenuList>
+                          </Menu>
+                        )}
                       </Td>
                     </Tr>
 

--- a/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
+++ b/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
@@ -121,7 +121,7 @@ const ResidentDirectoryTable = ({
         ref={tableRef}
       >
         <Table variant="showTable" verticalAlign="middle">
-          <Thead position="sticky" top={0} zIndex="docked">
+          <Thead>
             <Tr>
               <Th>Resident</Th>
               <Th>Status</Th>

--- a/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
+++ b/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
@@ -117,11 +117,11 @@ const ResidentDirectoryTable = ({
       <TableContainer
         marginTop="12px"
         height="70vh"
-        overflowY="scroll"
+        overflowY="unset"
         ref={tableRef}
       >
         <Table variant="showTable" verticalAlign="middle">
-          <Thead>
+          <Thead position="sticky" top={0} zIndex="docked">
             <Tr>
               <Th>Resident</Th>
               <Th>Status</Th>

--- a/frontend/src/theme/common/tableStyles.tsx
+++ b/frontend/src/theme/common/tableStyles.tsx
@@ -14,6 +14,11 @@ const Table: ComponentStyleConfig = {
         borderBottom: "1px",
         borderColor: "gray.100",
       },
+      thead: {
+        position: "sticky",
+        top: 0,
+        zIndex: "docked",
+      },
     },
   },
 };


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Set position to sticky for the table headers in `EmployeeDirectoryTable.tsx`, `LogRecordsTable.tsx`, and `ResidentDirectoryTable.tsx`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Check that all records still appear in the table 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## Screenshot
![image](https://github.com/uwblueprint/supportive-housing/assets/43042601/23ddeeba-8620-43bd-99c6-2dfa08578ebd) 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [x] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [x] I have documented this PR in the [Production Release Page](https://www.notion.so/uwblueprintexecs/fe28a97bfa5648d3bc3795b32b694acd?v=5565cfb35dcc45bb84f6528cb09517cd)
- [x] I have updated other Docs as needed
