### PR TITLE
[Braydon & Carolyn] Fix CSV convert issue when note or other fields have a comma

### DIFF
--- a/frontend/src/helper/CSVConverter.tsx
+++ b/frontend/src/helper/CSVConverter.tsx
@@ -8,8 +8,8 @@ const convertToCSVLog = (logRecord: LogRecord): CSVLog => {
     datetime: logRecord.datetime,
     employee: `${logRecord.employee.firstName} ${logRecord.employee.lastName}`,
     flagged: logRecord.flagged,
-    note: logRecord.note,
-    residentId: logRecord.residentId,
+    note: `${logRecord.note}`,
+    residentId: `${logRecord.residentId}`,
     tags: logRecord.tags != null ? logRecord.tags.join("; ") : "",
   };
 };

--- a/frontend/src/helper/CSVConverter.tsx
+++ b/frontend/src/helper/CSVConverter.tsx
@@ -4,12 +4,12 @@ import { CSVLog } from "../types/CSVLog";
 const convertToCSVLog = (logRecord: LogRecord): CSVLog => {
   return {
     attnTo: logRecord.attnTo != null ? `${logRecord.attnTo.firstName} ${logRecord.attnTo.lastName}` : "",
-    building: logRecord.building,
-    datetime: logRecord.datetime,
-    employee: `${logRecord.employee.firstName} ${logRecord.employee.lastName}`,
+    building: `"${logRecord.building}"`,
+    datetime: `"${logRecord.datetime}"`,
+    employee: `"${logRecord.employee.firstName} ${logRecord.employee.lastName}"`,
     flagged: logRecord.flagged,
-    note: `${logRecord.note}`,
-    residentId: `${logRecord.residentId}`,
+    note: `"${logRecord.note}"`,
+    residentId: `"${logRecord.residentId}"`,
     tags: logRecord.tags != null ? logRecord.tags.join("; ") : "",
   };
 };


### PR DESCRIPTION
## Notion task link
<!-- Please replace with your task's URL -->

[Task Name](https://www.notion.so/uwblueprintexecs/Fix-CSV-convert-issue-when-there-are-commas-a0aa935aa76d4a54842226791d738b53)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Wrapped double quotes around string values for almost all fields (notes, buildings, residents, etc.) to prevent commas creating a new column


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a new log record with a note with commas in it (eg. 1, 2, 3)
2. Export to CSV and check the csv to make sure the note doesn't create new columns


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Let us know if this is right way to deal with this issue


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [X] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [X] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [X] I have documented this PR in the [Production Release Page](https://www.notion.so/uwblueprintexecs/fe28a97bfa5648d3bc3795b32b694acd?v=5565cfb35dcc45bb84f6528cb09517cd)
- [X] I have updated other Docs as needed
