### PR TITLE
Fix sticky headers overlap (contribution farming)

### DIFF
--- a/frontend/src/theme/common/tableStyles.tsx
+++ b/frontend/src/theme/common/tableStyles.tsx
@@ -17,7 +17,6 @@ const Table: ComponentStyleConfig = {
       thead: {
         position: "sticky",
         top: 0,
-        zIndex: "docked",
       },
     },
   },


### PR DESCRIPTION
## Notion task link
N/A

![image](https://github.com/uwblueprint/supportive-housing/assets/43042601/e7afdcbc-1d30-4314-ad06-1aac36a20d74)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Removed `zIndex: "docked"` from the Thead styles in `tableStyles.tsx`

## Screenshot
![image](https://github.com/uwblueprint/supportive-housing/assets/43042601/a04ccd6c-932a-4b58-8f9e-ee784ba20c00)

## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [ ] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [ ] I have documented this PR in the [Production Release Page](https://www.notion.so/uwblueprintexecs/fe28a97bfa5648d3bc3795b32b694acd?v=5565cfb35dcc45bb84f6528cb09517cd)
- [ ] I have updated other Docs as needed
