### PR TITLE
Note, Tags, and Residents Column Formatting

### DIFF
--- a/frontend/src/components/forms/EditLog.tsx
+++ b/frontend/src/components/forms/EditLog.tsx
@@ -218,7 +218,7 @@ const EditLog = ({
     );
     setBuildingId(logRecord.building.id);
     const residentIds = residentOptions.filter(
-      (item) => logRecord.residents.includes(item.label),
+      (item) => logRecord.residents && logRecord.residents.includes(item.label),
     ).map((item) => item.value);
     setResidents(residentIds);
     setTags(logRecord.tags);
@@ -369,7 +369,7 @@ const EditLog = ({
                       placeholder="Select Residents"
                       onChange={handleResidentsChange}
                       defaultValue={residentOptions.filter(
-                        (item) => logRecord.residents.includes(item.label),
+                        (item) => logRecord.residents && logRecord.residents.includes(item.label),
                       )}
                       styles={selectStyle}
                     />

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -85,6 +85,16 @@ const LogRecordsTable = ({
     }));
   };
 
+  const formatNote = (note: string) => {
+    if (note && note.length > 0) {
+      if (note.length > 150) {
+        return note.substring(0, 150).concat("...");
+      }
+      return note;
+    }
+    return "";
+  };
+
   const formatList = (strArr: string[]) => {
     const strLength = strArr?.length;
     if (strLength === 1) {
@@ -191,7 +201,7 @@ const LogRecordsTable = ({
                         {formatList(record.residents)}
                       </Td>
                       <Td whiteSpace="normal" width="65%">
-                        {record.note}
+                        {formatNote(record.note)}
                       </Td>
                       <Td width="5%">{`${record.employee.firstName} ${record.employee.lastName}`}</Td>
                       <Td width="5%">

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -45,6 +45,28 @@ const DELETE_CONFIRMATION_HEADER = "Delete Log Record";
 const DELETE_CONFIRMATION_MESSAGE =
   "Are you sure you want to delete this log record? Deleting a log record will permanently remove it from your system.";
 
+const formatNote = (note: string) => {
+  const NOTE_LIMIT = 150;
+  if (note.length > NOTE_LIMIT) {
+    return note.substring(0, NOTE_LIMIT).concat("...");
+  }
+  return note;
+};
+
+const formatList = (strArr: string[]) => {
+  const strLength = strArr?.length;
+  if (strLength === 1) {
+    return strArr[0];
+  }
+  if (strLength === 2) {
+    return strArr?.join(", ");
+  }
+  if (strLength > 2) {
+    return `${strArr?.slice(0, 2).join(", ")}, ...`;
+  }
+  return "";
+};
+
 const LogRecordsTable = ({
   logRecords,
   tableRef,
@@ -83,31 +105,6 @@ const LogRecordsTable = ({
       ...prevEditOpenMap,
       [logId]: !prevEditOpenMap[logId],
     }));
-  };
-
-  const formatNote = (note: string) => {
-    const noteLimit = 150;
-    if (note && note.length > 0) {
-      if (note.length > noteLimit) {
-        return note.substring(0, noteLimit).concat("...");
-      }
-      return note;
-    }
-    return "";
-  };
-
-  const formatList = (strArr: string[]) => {
-    const strLength = strArr?.length;
-    if (strLength === 1) {
-      return strArr[0];
-    }
-    if (strLength === 2) {
-      return strArr?.join(", ");
-    }
-    if (strLength > 2) {
-      return `${strArr?.slice(0, 2).join(", ")}, ...`;
-    }
-    return "";
   };
 
   // fetch resident + employee data for log creation
@@ -201,13 +198,13 @@ const LogRecordsTable = ({
                       <Td whiteSpace="normal" width="5%">
                         {formatList(record.residents)}
                       </Td>
-                      <Td whiteSpace="normal" width="65%">
+                      <Td whiteSpace="normal" width="70%">
                         {formatNote(record.note)}
                       </Td>
-                      <Td width="5%">{`${record.employee.firstName} ${record.employee.lastName}`}</Td>
-                      <Td width="5%">
+                      <Td width="2.5%">{`${record.employee.firstName}`}</Td>
+                      <Td width="2.5%">
                         {record.attnTo
-                          ? `${record.attnTo.firstName} ${record.attnTo.lastName}`
+                          ? `${record.attnTo.firstName}`
                           : ""}
                       </Td>
                       <Td width="5%">
@@ -216,28 +213,28 @@ const LogRecordsTable = ({
                       <Td width="5%">
                         {(authenticatedUser?.role === "Admin" ||
                           authenticatedUser?.id === record.employee.id) && (
-                          <Menu>
-                            <MenuButton
-                              as={IconButton}
-                              aria-label="Options"
-                              icon={<VscKebabVertical />}
-                              w="36px"
-                              variant="ghost"
-                            />
-                            <MenuList>
-                              <MenuItem
-                                onClick={() => handleEditToggle(record.logId)}
-                              >
-                                Edit Log Record
+                            <Menu>
+                              <MenuButton
+                                as={IconButton}
+                                aria-label="Options"
+                                icon={<VscKebabVertical />}
+                                w="36px"
+                                variant="ghost"
+                              />
+                              <MenuList>
+                                <MenuItem
+                                  onClick={() => handleEditToggle(record.logId)}
+                                >
+                                  Edit Log Record
                               </MenuItem>
-                              <MenuItem
-                                onClick={() => handleDeleteToggle(record.logId)}
-                              >
-                                Delete Log Record
+                                <MenuItem
+                                  onClick={() => handleDeleteToggle(record.logId)}
+                                >
+                                  Delete Log Record
                               </MenuItem>
-                            </MenuList>
-                          </Menu>
-                        )}
+                              </MenuList>
+                            </Menu>
+                          )}
                       </Td>
                     </Tr>
 

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -85,18 +85,18 @@ const LogRecordsTable = ({
     }));
   };
 
-  const formatTags = (strArr: string[]) => {
-    const strLength = strArr.length;
-    if (strLength === 0) {
-      return "";
-    }
+  const formatList = (strArr: string[]) => {
+    const strLength = strArr?.length;
     if (strLength === 1) {
       return strArr[0];
     }
     if (strLength === 2) {
-      return strArr.join(", ");
+      return strArr?.join(", ");
     }
-    return `${strArr.slice(0, 2).join(", ")}, ...`;
+    if (strLength > 2) {
+      return `${strArr?.slice(0, 2).join(", ")}, ...`;
+    }
+    return "";
   };
 
   // fetch resident + employee data for log creation
@@ -188,7 +188,7 @@ const LogRecordsTable = ({
                       <Td width="5%">{date}</Td>
                       <Td width="5%">{time}</Td>
                       <Td whiteSpace="normal" width="5%">
-                        {record.residents?.join("\n")}
+                        {formatList(record.residents)}
                       </Td>
                       <Td whiteSpace="normal" width="65%">
                         {record.note}
@@ -200,7 +200,7 @@ const LogRecordsTable = ({
                           : ""}
                       </Td>
                       <Td width="5%">
-                        {formatTags(record.tags)}
+                        {formatList(record.tags)}
                       </Td>
                       <Td width="5%">
                         {(authenticatedUser?.role === "Admin" ||

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -85,6 +85,20 @@ const LogRecordsTable = ({
     }));
   };
 
+  const formatTags = (strArr: string[]) => {
+    const strLength = strArr.length;
+    if (strLength === 0) {
+      return "";
+    }
+    if (strLength === 1) {
+      return strArr[0];
+    }
+    if (strLength === 2) {
+      return strArr.join(", ");
+    }
+    return `${strArr.slice(0, 2).join(", ")}, ...`;
+  };
+
   // fetch resident + employee data for log creation
   const getLogEntryOptions = async () => {
     const residentsData = await ResidentAPIClient.getResidents({
@@ -157,6 +171,7 @@ const LogRecordsTable = ({
                 <Th>Note</Th>
                 <Th>Employee</Th>
                 <Th>Attn To</Th>
+                <Th>Tags</Th>
                 <Th> </Th>
               </Tr>
             </Thead>
@@ -175,7 +190,7 @@ const LogRecordsTable = ({
                       <Td whiteSpace="normal" width="5%">
                         {record.residents?.join("\n")}
                       </Td>
-                      <Td whiteSpace="normal" width="70%">
+                      <Td whiteSpace="normal" width="65%">
                         {record.note}
                       </Td>
                       <Td width="5%">{`${record.employee.firstName} ${record.employee.lastName}`}</Td>
@@ -183,6 +198,9 @@ const LogRecordsTable = ({
                         {record.attnTo
                           ? `${record.attnTo.firstName} ${record.attnTo.lastName}`
                           : ""}
+                      </Td>
+                      <Td width="5%">
+                        {formatTags(record.tags)}
                       </Td>
                       <Td width="5%">
                         {(authenticatedUser?.role === "Admin" ||

--- a/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
+++ b/frontend/src/components/pages/HomePage/LogRecordsTable.tsx
@@ -86,9 +86,10 @@ const LogRecordsTable = ({
   };
 
   const formatNote = (note: string) => {
+    const noteLimit = 150;
     if (note && note.length > 0) {
-      if (note.length > 150) {
-        return note.substring(0, 150).concat("...");
+      if (note.length > noteLimit) {
+        return note.substring(0, noteLimit).concat("...");
       }
       return note;
     }

--- a/frontend/src/components/pages/HomePage/SearchAndFilters.tsx
+++ b/frontend/src/components/pages/HomePage/SearchAndFilters.tsx
@@ -184,7 +184,7 @@ const SearchAndFilters = ({
   }, []);
 
   return (
-    <Card style={{ textAlign: "left" }}>
+    <Card style={{ textAlign: "left", zIndex: 9999 }}>
       <Box padding="8px 16px 20px">
         <Text fontSize="12px" fontWeight="700" color="#6D8788" align="left">
           FILTER BY

--- a/frontend/src/theme/common/tableStyles.tsx
+++ b/frontend/src/theme/common/tableStyles.tsx
@@ -17,6 +17,7 @@ const Table: ComponentStyleConfig = {
       thead: {
         position: "sticky",
         top: 0,
+        zIndex: 1,
       },
     },
   },


### PR DESCRIPTION
## Notion task link
<!-- Please replace with your task's URL -->

[Notes Column Limitation](https://www.notion.so/uwblueprintexecs/Notes-Column-Limitation-d54b79f5b52b403fba198ca1f47c0b65)
[Tags Column](https://www.notion.so/uwblueprintexecs/Tags-Column-1fb05a3bb1b64d1c9be32349ed82c15a)
[Residents Column Limitation](https://www.notion.so/uwblueprintexecs/Residents-Column-Limitation-eace22b5f3f746f7a669d47a49ebc34c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added formatting functions to `LogRecordsTable.tsx`
* Added extra null check in `EditLog.tsx` because of a TypeScript/eslint issue
* Fixed bug with table header where the options button overlapped the heading by adding a z-index value to `tableStyles.tsx`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create new log records with 1 resident, 2 residents, 3 residents, and 4 residents
2. Create new log records with a note less than 150 characters and one greater than 150 characters
3. Create new log records with 1 tag, 2 tags, 3 tags, and 4 tags
4. Check that formatting for note, tags, and residents is correct


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* How many characters should be shown for the note?

## Screenshot
![image](https://github.com/uwblueprint/supportive-housing/assets/43042601/346ec37e-c325-457b-88e0-de7607c026fc)


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [x] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [x] I have documented this PR in the [Production Release Page](https://www.notion.so/uwblueprintexecs/fe28a97bfa5648d3bc3795b32b694acd?v=5565cfb35dcc45bb84f6528cb09517cd)
- [x] I have updated other Docs as needed
