### PR TITLE
[BUG] Pagination Total Num of Pages Fix

### DIFF
--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -40,7 +40,7 @@ const Pagination = ({
   setResultsPerPage,
   getRecords,
 }: Props): React.ReactElement => {
-  const numPages = Math.ceil(numRecords / resultsPerPage);
+  const numPages = Math.ceil(Math.max(1, numRecords) / resultsPerPage);
 
   const handleNumberInputChange = (
     newUserPageNumString: string,


### PR DESCRIPTION
## Notion task link
<!-- Please replace with your task's URL -->

**No Associated Task**

This ticket aims to resolve an issue occurring on any page leveraging the `Pagination` component, in which an error state in the component will briefly be flashed since the total num of pages at that point is initially set to 0, while the user's page number is by default 1 (thus we end up displaying `Page 1 of 0`, leading to the error state temporarily). This fix resolves that issue.


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The denominator of the page (numPages) is calculated using the current num of records ; on page load, this will be 0 (as we are still fetching the number of records), and so we want to simply set this to be the max of each value (1 and numRecords) so that when records are loading, we see `Page X of 1`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify for log records, residents, and the employee page that the error state on the pagination component does NOT appear (and that initially we just see page 1 of 1)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [ ] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [ ] I have documented this PR in the [Production Release Page](https://www.notion.so/uwblueprintexecs/fe28a97bfa5648d3bc3795b32b694acd?v=5565cfb35dcc45bb84f6528cb09517cd)
- [ ] I have updated other Docs as needed
