### PR TITLE
Resident Status Style

### DIFF
--- a/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
+++ b/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
@@ -62,6 +62,7 @@ const getFormattedDatesAndStatus = (resident: Resident) => {
   let endDate;
   let status = ResidentStatus.CURRENT;
   const currentDate = new Date();
+  currentDate.setHours(0,0,0,0);
   if (resident.dateLeft != null) {
     const endDateObj = convertToDate(resident.dateLeft);
     endDate = getFormattedDateAndTime(endDateObj, true);
@@ -164,7 +165,7 @@ const ResidentDirectoryTable = ({
           <Thead>
             <Tr>
               <Th>Resident</Th>
-              <Th>Status</Th>
+              <Th textAlign="center">Status</Th>
               <Th>Building</Th>
               <Th>Residency Start Date</Th>
               <Th>Residency End Date</Th>

--- a/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
+++ b/frontend/src/components/pages/ResidentDirectory/ResidentDirectoryTable.tsx
@@ -180,8 +180,8 @@ const ResidentDirectoryTable = ({
               // TODO: Remove non-null assertion from residentId
               return (
                 <Tr key={resident.id} style={{ verticalAlign: "middle" }}>
-                  <Td width="20%">{resident.residentId!}</Td>
-                  <Td width="15%"
+                  <Td width="10%">{resident.residentId!}</Td>
+                  <Td width="25%"
                     textStyle="user-status-label"
                     textAlign="center"
                   >
@@ -189,6 +189,7 @@ const ResidentDirectoryTable = ({
                       backgroundColor={getStatusColor(status)}
                       borderRadius="40px"
                       padding="6px 0px"
+                      marginX="20%"
                     >
                       {status}
                     </Box>

--- a/frontend/src/types/ResidentTypes.ts
+++ b/frontend/src/types/ResidentTypes.ts
@@ -34,3 +34,9 @@ export type CreateResidentParams = Omit<
 export type EditResidentParams = Omit<Resident, "residentId" | "building"> & {
   buildingId: number;
 };
+
+export enum ResidentStatus {
+  FUTURE = "Future",
+  PAST = "Past",
+  CURRENT = "Current",
+}


### PR DESCRIPTION
## Notion task link
<!-- Please replace with your task's URL -->

N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added ResidentStatus enum to `ResidentTypes.ts` to ensure status string values are consistant 
* Updated resident status function in `ResidentDirectoryTable.tsx` to include "Future" as a status
* Added getStatusColor method to `ResidentDirectoryTable.tsx` to convert the status to color 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create three new residents (use `create-residents.sh`)
2. Edit the Start Date and End Date for the residents and verify that the status is correct


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Are the colours for the statuses okay? (They match the employee directory)

## Screenshot
![image](https://github.com/uwblueprint/supportive-housing/assets/43042601/a78c09d0-30c5-4ea2-8df1-3f2f2fb97c88)

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] If I have made API changes, I have updated the [REST API Docs](https://www.notion.so/uwblueprintexecs/REST-Endpoints-05ce60312bb943439dfda42bb1318536)
- [x] IF I have made changes to the db/models, I have updated the [Data Models Page](https://www.notion.so/uwblueprintexecs/Data-Models-760f8aa06b244eb0842c079ad77987b0)
- [x] I have documented this PR in the [Production Release Page](https://www.notion.so/uwblueprintexecs/fe28a97bfa5648d3bc3795b32b694acd?v=5565cfb35dcc45bb84f6528cb09517cd)
- [x] I have updated other Docs as needed
